### PR TITLE
Includes Hapi local node server

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,20 +2,23 @@
   "name": "sketch-modular-js",
   "version": "0.0.0",
   "description": "A skeleton for modular JS based project.",
-  "main": "src/js/Main.js",
+  "main": "server.js",
   "scripts": {
-    "test": "node_modules/.bin/mocha"
+      "test": "node_modules/.bin/mocha"
   },
   "author": "Kumar Kundan",
   "contributors": [
-    "Ashwin Hegde <ashwin.hegde3@gmail.com>"
+      "Ashwin Hegde <ashwin.hegde3@gmail.com>"
   ],
   "license": "MIT",
+  "dependencies": {
+      "hapi": "^8.4.0"
+  },
   "devDependencies": {
-    "grunt": "^0.4.5",
-    "grunt-contrib-jshint": "^0.11.2",
-    "grunt-contrib-requirejs": "^0.4.4",
-    "mocha": "^2.2.4",
-    "chai": "^2.3.0"
+      "grunt": "^0.4.5",
+      "grunt-contrib-jshint": "^0.11.2",
+      "grunt-contrib-requirejs": "^0.4.4",
+      "mocha": "^2.2.4",
+      "chai": "^2.3.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,23 @@
+var Hapi = require('hapi');
+
+var server = new Hapi.Server();
+
+server.connection({
+	host: 'localhost',
+	port: 3000
+});
+
+server.route({
+	method: 'GET',
+	path: '/{param*}',
+	handler: {
+		directory: {
+			path: '.',
+			listing: true
+		}
+	}
+});
+
+server.start(function() {
+	server.log("Info", "Server running at: ", server.info.uri);
+});

--- a/src/js/Main.js
+++ b/src/js/Main.js
@@ -1,4 +1,4 @@
-require(['../../config/ConfigPaths', 'Globals'], function(ConfigPaths, Globals) {
+require(['../../config/ConfigPaths', 'Globals'], function() {
     "use strict";
 	/**
 	* @description test....


### PR DESCRIPTION
Alternative solution for local node server; Try `npm install -g http-server`.

Command for execution of Hapi local server integrated with scaffolding:
`node server.js`. By default it has been configured to 3000 port.
